### PR TITLE
Mcp.sample.jsonにgithubサーバを追加

### DIFF
--- a/mcp.sample.json
+++ b/mcp.sample.json
@@ -94,9 +94,17 @@
 		"autoApprove": []
 	  },
 	    	  "github": {
-		"url": "https://api.githubcopilot.com/mcp/",
-		"headers": {
-		  "Authorization": "Bearer YOUR_GITHUB_PAT"
+		"command": "docker",
+		"args": [
+		  "run",
+		  "-i",
+		  "--rm",
+		  "-e",
+		  "GITHUB_PERSONAL_ACCESS_TOKEN",
+		  "ghcr.io/github/github-mcp-server"
+		],
+		"env": {
+		  "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_GITHUB_PAT"
 		}
 	  },
 	  "awslabs.git-repo-research-mcp-server": {

--- a/mcp.sample.json
+++ b/mcp.sample.json
@@ -93,15 +93,15 @@
 		"disabled": false,
 		"autoApprove": []
 	  },
-	  "github": {
-		"command": "npx",
-		"args": ["-y", "@modelcontextprotocol/server-github"],
-		"env": {
-		  "GITHUB_PERSONAL_ACCESS_TOKEN": "[your-github-token]"
-		},
-		"disabled": true,
-		"autoApprove": []
-	  },
+	    "github": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-github"],
+    "env": {
+      "GITHUB_PERSONAL_ACCESS_TOKEN": "[your-github-token]"
+    },
+    "disabled": false,
+    "autoApprove": []
+  },
 	  "awslabs.git-repo-research-mcp-server": {
 		"command": "uvx",
 		"args": ["awslabs.git-repo-research-mcp-server@latest"],

--- a/mcp.sample.json
+++ b/mcp.sample.json
@@ -93,15 +93,12 @@
 		"disabled": false,
 		"autoApprove": []
 	  },
-	    "github": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-github"],
-    "env": {
-      "GITHUB_PERSONAL_ACCESS_TOKEN": "[your-github-token]"
-    },
-    "disabled": false,
-    "autoApprove": []
-  },
+	    	  "github": {
+		"url": "https://api.githubcopilot.com/mcp/",
+		"headers": {
+		  "Authorization": "Bearer YOUR_GITHUB_PAT"
+		}
+	  },
 	  "awslabs.git-repo-research-mcp-server": {
 		"command": "uvx",
 		"args": ["awslabs.git-repo-research-mcp-server@latest"],


### PR DESCRIPTION
```
## Type of Change
- [ ] feat: New feature or enhancement
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [x] chore: Maintenance, refactoring, or tooling
- [ ] breaking: Breaking change

## Description
Updated the `github` MCP server configuration in `mcp.sample.json` to use a local Docker-based setup. This allows users to run the GitHub MCP server locally via the official `ghcr.io/github/github-mcp-server` Docker image.

## Related Issues
- Closes #
- Related to #

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed (Verified the configuration structure matches the requested Docker setup)

## Checklist
- [x] Code follows project coding standards
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
- [ ] Tests added/updated (if applicable)
```

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-cef2d65d-72e6-47d8-8c29-fd6b6e953ff8) · [Cursor](https://cursor.com/background-agent?bcId=bc-cef2d65d-72e6-47d8-8c29-fd6b6e953ff8)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)